### PR TITLE
Authenticate dockerhub pulls

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,6 +5,9 @@ jobs:
     working_directory: ~/manifold_airflow_dags
     docker:
       - image: circleci/python:3.6
+        auth:
+          username: $DOCKERHUB_USER
+          password: $DOCKERHUB_PASSWORD
         environment:
           PIPENV_VENV_IN_PROJECT: true
     steps:
@@ -19,6 +22,9 @@ jobs:
   qa_deploy:
     docker:
       - image: circleci/python:3.6
+        auth:
+          username: $DOCKERHUB_USER
+          password: $DOCKERHUB_PASSWORD
         environment:
           PIPENV_VENV_IN_PROJECT: true
     steps:
@@ -41,6 +47,9 @@ jobs:
   prod_deploy:
     docker:
       - image: circleci/python:3.6
+        auth:
+          username: $DOCKERHUB_USER
+          password: $DOCKERHUB_PASSWORD
         environment:
           PIPENV_VENV_IN_PROJECT: true
     steps:


### PR DESCRIPTION
dockerhub will begin to throttle non anthenticated pulls so we need to
authenticate our pulls now.