### PR TITLE
CircleCI config change

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,12 +69,12 @@ jobs:
 
 workflows:
   version: 2
-  qa_deploy:
+  run_tests:
     jobs:
       - lint_and_test
+  qa_deploy:
+    jobs:
       - qa_deploy:
-          requires:
-            - lint_and_test
           filters:
             branches:
               only:

--- a/manifold_airflow_dags/maintenance_funcake_prod-log-cleanup.py
+++ b/manifold_airflow_dags/maintenance_funcake_prod-log-cleanup.py
@@ -17,7 +17,7 @@ DAG_ID = os.path.basename(__file__).replace(".pyc", "").replace(".py", "")
 START_DATE = airflow.utils.dates.days_ago(1)
 BASE_LOG_FOLDER = conf.get("logging", "BASE_LOG_FOLDER")
 # How often to Run. @daily - Once a day at Midnight
-SCHEDULE_INTERVAL = "@daily"
+SCHEDULE_INTERVAL = "@weekly"
 # Who is listed as the owner of this DAG in the Airflow Web Server
 DAG_OWNER_NAME = "maintenance"
 # List of email address to send email alerts to if this job fails


### PR DESCRIPTION
- Having workflows on feature branches labeled qa_deploy is misleading since they don't deploy anywhere.  This updates the label for those workflows to be run_tests and adds a qa_deploy workflow for changes pushed to main.
- Also changes the schedule for cleaning up funcake logs to run weekly since they don't get removed as often as other logs