### PR TITLE
Remove QA env from script

### DIFF
--- a/manifold_airflow_dags/manifold_database_sync_dag.py
+++ b/manifold_airflow_dags/manifold_database_sync_dag.py
@@ -124,7 +124,7 @@ sudo su root - bash -c \
 ##
 ## If running locally on a Vagrant Box, replace the list ["QA","STAGE"] with ["VAGRANT"]
 ##
-for server in ["QA","STAGE"]:
+for server in ["STAGE"]:
     COPY_DB_DUMP_TO_SERVER = S3ToSFTPOperator(
         task_id=f"copy_db_dump_to_{server}",
         s3_conn_id=AIRFLOW_S3_CONN_ID,


### PR DESCRIPTION
It is not desired to have the QA db sync'd as it is the main testing environment for new features.