### PR TITLE
Update conn_id for database sync dag

### DIFF
--- a/manifold_airflow_dags/manifold_database_sync_dag.py
+++ b/manifold_airflow_dags/manifold_database_sync_dag.py
@@ -127,7 +127,7 @@ sudo su root - bash -c \
 for server in ["STAGE"]:
     COPY_DB_DUMP_TO_SERVER = S3ToSFTPOperator(
         task_id=f"copy_db_dump_to_{server}",
-        s3_conn_id=AIRFLOW_S3_CONN_ID,
+        aws_conn_id=AIRFLOW_S3_CONN_ID,
         s3_bucket=AIRFLOW_DATA_BUCKET,
         s3_key="{{ ti.xcom_pull(task_ids='get_latest_db_dump_in_s3')['full_path'] }}",
         sftp_conn_id=f"MANIFOLD_{server}_DB",


### PR DESCRIPTION
Airflow QA is currently broken with this error:
Airflow.exceptions.AirflowException: Invalid arguments were passed to S3ToSFTPOperator (task_id: copy_db_dump_to_STAGE). Invalid arguments were:
**kwargs: {'s3_conn_id': 'AIRFLOW_S3'}

With recent updates, s3_conn_id is no longer a valid parameter for this operator.  This updates the parameter to aws_conn_id.