### PR TITLE
Quotation escaping update

### DIFF
--- a/manifold_database_sync_dag.py
+++ b/manifold_database_sync_dag.py
@@ -76,7 +76,7 @@ POST_SLACK = PythonOperator(
 
 # Create a temporary SQL script to Terminate connections to Manifold DB so we can drop the DB.
 disconnect_db_sql = """
-  sudo su - postgres bash -c 'echo "select pg_terminate_backend(pid) from pg_stat_activity where datname=\'manifold\' AND application_name!=\'psql\';" > /tmp/disconnect_db.sql'
+  sudo su - postgres bash -c "echo \"select pg_terminate_backend(pid) from pg_stat_activity where datname='manifold' AND application_name!='psql';\" > /tmp/disconnect_db.sql"
 """
 
 # Restore the database:


### PR DESCRIPTION
This was being written to the /tmp/disconnect_db.sql file
`select pg_terminate_backend(pid) from pg_stat_activity where datname=\'manifold\' AND application_name!=\'psql\';`

This is what is needed
`select pg_terminate_backend(pid) from pg_stat_activity where datname='manifold' AND application_name!='psql';`

Updating the nested quotation syntax should fix this